### PR TITLE
feat: inject selector for scroll container as dependency

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -81,7 +81,7 @@ const switchLocale = () => {
 };
 
 onMounted(() => {
-  const browserLanguage = navigator.language;
+  const browserLanguage = window.navigator.language;
 
   locale.value = browserLanguage;
   imagePath.value = updateImagePath(locale);

--- a/src/composables/useElementIsVisible/component.js
+++ b/src/composables/useElementIsVisible/component.js
@@ -41,6 +41,8 @@ const UseElementIsVisible = defineComponent({
       if (slots.default) {
         return h(props.as, { ref: target }, slots.default(data));
       }
+
+      return h(props.as, { ref: target });
     };
   },
 });

--- a/src/composables/useElementIsVisible/component.js
+++ b/src/composables/useElementIsVisible/component.js
@@ -1,6 +1,7 @@
-import { ref, h, defineComponent, reactive, onMounted } from "vue";
+import { ref, h, defineComponent, reactive, inject } from "vue";
 
 import { useElementIsVisible } from ".";
+import { useOnMounted } from "../useOnMounted";
 
 const UseElementIsVisible = defineComponent({
   name: 'UseElementIsVisible',
@@ -24,10 +25,11 @@ const UseElementIsVisible = defineComponent({
   },
 
   setup(props, { slots }) {
+    const selectorForScrollContainer = inject('selectorForScrollContainer');
+
     const scrollContainer = ref(null);
-    onMounted(() => {
-      //TODO: How to set scroll container globally?
-      scrollContainer.value = document.querySelector(".content");
+    useOnMounted(() => {
+      scrollContainer.value = selectorForScrollContainer ? document.querySelector(selectorForScrollContainer) : document;
     });
 
     const target = ref(null);

--- a/src/composables/useElementIsVisible/function.js
+++ b/src/composables/useElementIsVisible/function.js
@@ -9,7 +9,7 @@ import { useOnMounted } from "@/composables/useOnMounted";
  * @param {boolean} abortIfVisible Deregister event listener as soon as the element is visible?
  * @param {object} scrollContainer  Scroll container on whose scroll event is listened
  * @param {number} elementGetsVisibleAt Percentage value as decimal number at which the element's visibility should be triggered. The bigger the value the later the element is visible.
- * @param {number} elementGetsUnvisibleAt Percentage value as decimal number at which the element's visibility should be triggered. The bigger the value the later the element is invisible.
+ * @param {number} elementGetsInvisibleAt Percentage value as decimal number at which the element's visibility should be triggered. The bigger the value the later the element is invisible.
  *
  * @returns {boolean} whether the element is visible
  */

--- a/src/main.js
+++ b/src/main.js
@@ -26,4 +26,5 @@ initializeScrollSpy(app);
 
 useVisible(app);
 
+app.provide('selectorForScrollContainer', ".content");
 app.mount("#app");

--- a/src/views/Experiences.vue
+++ b/src/views/Experiences.vue
@@ -59,7 +59,7 @@
 </template>
 
 <script setup>
-import { computed, onMounted, ref } from "vue";
+import { computed } from "vue";
 import { useI18n } from "vue-i18n";
 
 import Card from "@/components/Card";
@@ -121,11 +121,6 @@ const events = computed(() => [
     },
   },
 ]);
-
-const scrollContainer = ref(null);
-onMounted(() => {
-  scrollContainer.value = document.querySelector(".content");
-});
 </script>
 
 <style scoped>


### PR DESCRIPTION
Scroll container can now be accessed by dependency injection globally.
At the highst level of the app the selector is provided. This means it's available in every component.

Closes #50.