### PR TITLE
refactor: spelling errors, job title and invert flags shown

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -94,9 +94,9 @@ const imagePath = ref<string>(GbUrl);
 
 function updateImagePath(locale: Ref<string>) {
   if (locale.value.startsWith(Locales.DE)) {
-    return DeUrl;
+    return GbUrl;
   }
-  return GbUrl;
+  return DeUrl;
 }
 
 function switchLocale() {

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -91,7 +91,7 @@
                 "description": "Mitarbeit in diversen Projekten im Kontext von SAP EWM. Besonders ein Template für manuelle Läger in der Unternehmensgruppe mit SAPUI5-Applikationen im FIORI-Launchpad für die mobile Bedienung durch die Lagermitarbeiter."
             },
             "dtsp": {
-                "title": "Development Consutlant",
+                "title": "Development Consultant",
                 "yearStart": "2024",
                 "yearEnd": "heute",
                 "organisation": "SAP Deutschland SE & Co. KG",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -26,7 +26,7 @@
     },
     "intro": {
         "hello": "Hallo, ich bin",
-        "jobTitle": "Softwareentwickler",
+        "jobTitle": "Development Consultant",
         "studies": "M. Sc. Informatik"
     },
     "about": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -91,7 +91,7 @@
                 "description": "Participated in various projects in the context of SAP EWM. Especially a template for manual warehouses in the group of companies with SAPUI5 applications in the SAP FIORI Launchpad for mobile operation by warehouse employees."
             },
             "dtsp": {
-                "title": "Development Consutlant",
+                "title": "Development Consultant",
                 "yearStart": "2024",
                 "yearEnd": "today",
                 "organisation": "SAP Deutschland SE & Co. KG",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -26,7 +26,7 @@
     },
     "intro": {
         "hello": "Hello I'm",
-        "jobTitle": "Software Developer",
+        "jobTitle": "Development Consultant",
         "studies": "M. Sc. Computer Science"
     },
     "about": {


### PR DESCRIPTION
This PR introduces 3 changes:
1. Fixes spelling mistake in job title of my latest experience
2. Adapts job title in the intro section to match my current job title
3. Shows the flag of the inactive language to make switching more intuitive